### PR TITLE
Remove wrappers for parsoid output

### DIFF
--- a/lib/differ.js
+++ b/lib/differ.js
@@ -64,27 +64,10 @@ VisualDiffer.takeScreenshots = function(opts, logger, cb) {
 				}
 
 				page.evaluate(function() {
+
 					// Open navboxes and other collapsed content
 					$("table.collapsible tr").show();
 					$(".NavContent").show();
-
-					// Hide navigation
-					$("div#mw-page-base").hide();
-					$("div#mw-head-base").hide();
-					$("div#mw-navigation").hide();
-					$("div#footer").hide();
-					$("div.suggestions").hide();
-
-					// Hide site notice and other anchors
-					$("a#top").hide();
-					$("div#siteNotice").hide();
-					$("div#centralNotice").hide();
-
-					// Hide top header + site byline + other non-display/navigational elts. not present in parsoid output.
-					$("h1.firstHeading").hide();
-					$("div#siteSub").hide();
-					$("div#contentSub").hide();
-					$("div#jump-to-nav").hide();
 
 					// Hide toc
 					$("div.toc").hide();
@@ -100,7 +83,14 @@ VisualDiffer.takeScreenshots = function(opts, logger, cb) {
 					// Hide show/hide buttons
 					$("span.collapseButton").hide();
 					$("a.NavToggle").hide();
+
+					// Finally remove all chrome, only keep the actual
+					// content.
+					document.body.innerHTML = $("div#mw-content-text").html();
+					document.body.classList.add('mw-body');
+					document.body.classList.add('mw-body-content');
 				});
+
 				page.render(opts.phpScreenShot, function() {
 					logger("php done!");
 					phpDone = true;
@@ -132,7 +122,7 @@ VisualDiffer.takeScreenshots = function(opts, logger, cb) {
 							$("*.NavContent").show();
 
 							// Fix problem with parsoid css to reduce rendering diffs
-							$('<style type="text/css">span.reference {line-height: 1;} sup,sub {line-height:1;}</style>').appendTo('head');
+							$('<style type="text/css">span.reference {line-height: 1;} sup,sub {line-height:1;} body.mw-body { padding: 1.25em 1.5em 1.5em 1.5em; }</style>').appendTo('head');
 
 							if (dumpOutput) {
 								var header = document.head.innerHTML.replace(/href="\/\//g, 'href="http://');


### PR DESCRIPTION
These shouldn't be necessary anymore ... once upstream changes are deployed.

Will leave this as a pull until then.
